### PR TITLE
Lint for duplicate Sass variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ module.exports = {
     "scss/at-import-partial-extension-blacklist": ["scss"],
     "scss/dollar-variable-colon-space-after": "always",
     "scss/dollar-variable-colon-space-before": "never",
+    "scss/no-duplicate-dollar-variables": true,
     "scss/operator-no-unspaced": true,
     "scss/selector-no-redundant-nesting-selector": true,
     "selector-list-comma-newline-after": "always",


### PR DESCRIPTION
This enables the `scss/no-duplicate-dollar-variables` from the
stylelint-scss plugin.

https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/no-duplicate-dollar-variables/README.md