### PR TITLE
Lint for concatenated selectors using Sass's `&`

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,11 @@ module.exports = {
     "scss/selector-no-redundant-nesting-selector": true,
     "selector-list-comma-newline-after": "always",
     "selector-max-id": 0,
+    "selector-nested-pattern": [
+      "^(?!&__|&--|&-|&_).*", {
+        "message": "Don't concatenate selectors using Sass's parent selector (`&`)."
+      }
+    ],
     "selector-no-qualifying-type": true,
     "selector-no-vendor-prefix": true,
     "selector-pseudo-class-case": "lower",


### PR DESCRIPTION
This enables the `selector-nested-pattern` to lint for selectors that
are concatenated using Sass's parent selector (`&`). It follows
our [Guide]:

> Don't concatenate selectors using Sass's parent selector (&).

The following is considered a warning:

```
.foo {
  &__bar {
    color: red;
  }
}
```

It should instead be "flattened" and written as:

```
.foo__bar {
  color: red;
}
```

Linter documentation: https://stylelint.io/user-guide/rules/selector-nested-pattern/

Thanks to this [blog post] by Lara Schenck for the technique!

[Guide]: https://github.com/thoughtbot/guides/tree/master/style/sass
[blog post]: https://notlaura.com/control-sass-selector-concatenation-with-a-stylelint-rule/