### PR TITLE
Enable scss/map-keys-quotes rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ module.exports = {
     "scss/at-rule-no-unknown": true,
     "scss/dollar-variable-colon-space-after": "always",
     "scss/dollar-variable-colon-space-before": "never",
+    "scss/map-keys-quotes": "always",
     "scss/no-duplicate-dollar-variables": true,
     "scss/operator-no-unspaced": true,
     "scss/selector-no-redundant-nesting-selector": true,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "stylelint-config-recommended": "^2.2.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.0.0",
     "stylelint-order": "^3.0.0",
-    "stylelint-scss": "^3.5.4"
+    "stylelint-scss": ">=3.9.3"
   },
   "keywords": [
     "stylelint",


### PR DESCRIPTION
Require quoted keys in Sass maps.

Documentation
https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/map-keys-quotes/README.md