### PR TITLE
Enable scss/selector-no-union-class-name

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,13 +64,9 @@ module.exports = {
     "scss/no-duplicate-dollar-variables": true,
     "scss/operator-no-unspaced": true,
     "scss/selector-no-redundant-nesting-selector": true,
+    "scss/selector-no-union-class-name": true,
     "selector-list-comma-newline-after": "always",
     "selector-max-id": 0,
-    "selector-nested-pattern": [
-      "^(?!&__|&--|&-|&_).*", {
-        "message": "Don't concatenate selectors using Sass's parent selector (`&`)."
-      }
-    ],
     "selector-no-qualifying-type": true,
     "selector-no-vendor-prefix": true,
     "selector-pseudo-class-case": "lower",


### PR DESCRIPTION
This allows us to remove our custom rule which linted for selector
concatenation using Sass's parent selector.

Documentation
https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/selector-no-union-class-name/README.md