### PR TITLE
Enable case rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports = {
     "number-no-trailing-zeros": true,
     "order/properties-alphabetical-order": true,
     "plugin/declaration-block-no-ignored-properties": true,
+    "property-case": "lower",
     "property-no-vendor-prefix": true,
     "rule-empty-line-before": [
       "always",
@@ -75,6 +76,8 @@ module.exports = {
     "selector-type-case": "lower",
     "shorthand-property-no-redundant-values": true,
     "string-quotes": "double",
+    "unit-case": "lower",
+    "value-keyword-case": "lower",
     "value-no-vendor-prefix": true
   }
 }


### PR DESCRIPTION
We already had the `color-hex-case`, `selector-pseudo-class-case`,
`selector-pseudo-element-case`, and `selector-type-case` rules enabled
and all set to `"lower"`.

This commit enables the remaining stylelint rules for linting case:

- https://stylelint.io/user-guide/rules/property-case
- https://stylelint.io/user-guide/rules/unit-case
- https://stylelint.io/user-guide/rules/value-keyword-case