### PR TITLE
Enable SCSS `*-parentheses-space-*` rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,9 +54,12 @@ module.exports = {
         ]
       }
     ],
+    "scss/at-else-if-parentheses-space-before": "never",
     "scss/at-extend-no-missing-placeholder": true,
+    "scss/at-function-parentheses-space-before": "never",
     "scss/at-import-no-partial-leading-underscore": true,
     "scss/at-import-partial-extension-blacklist": ["scss"],
+    "scss/at-mixin-parentheses-space-before": "never",
     "scss/at-rule-no-unknown": true,
     "scss/dollar-variable-colon-space-after": "always",
     "scss/dollar-variable-colon-space-before": "never",


### PR DESCRIPTION
These rules lint for spaces before Sass `@else if`, `@function`, and
`@mixin` parentheses. They will catch things like…

A space between `if` and the opening parentheses:

```scss
@else if ($condition) { }
//      ↑
````

A space between the function name and the opening parentheses:

```scss
@function foo ($arg) { }
//           ↑
````

A space between the mixin name and the opening parentheses:

```scss
@mixin foo ($arg) { }
//        ↑
````

Documentation:

- https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/at-else-if-parentheses-space-before/README.md
- https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/at-function-parentheses-space-before/README.md
- https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/at-mixin-parentheses-space-before/README.md