### PR TITLE
Enable `selector-list-comma-*` rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,8 @@ module.exports = {
     "scss/selector-no-redundant-nesting-selector": true,
     "scss/selector-no-union-class-name": true,
     "selector-list-comma-newline-after": "always",
+    "selector-list-comma-newline-before": "never-multi-line",
+    "selector-list-comma-space-before": "never",
     "selector-max-id": 0,
     "selector-no-qualifying-type": true,
     "selector-no-vendor-prefix": true,


### PR DESCRIPTION
These rules lint the spaces and newlines around the commas of
selector lists. They will catch things like…

A comma bumped to a newline:

```scss
   a
   , b { color: pink; }
// ↑
```

A space before the comma:

```scss
  a , b { color: pink; }
// ↑
```

Documentation:

- https://stylelint.io/user-guide/rules/selector-list-comma-newline-before
- https://stylelint.io/user-guide/rules/selector-list-comma-space-before