### PR TITLE
Enable `no-empty-*` rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,8 @@ module.exports = {
     "media-query-list-comma-newline-before": "never-multi-line",
     "media-query-list-comma-space-after": "always",
     "media-query-list-comma-space-before": "never",
+    "no-empty-first-line": true,
+    "no-empty-source": true,
     "no-eol-whitespace": true,
     "no-missing-end-of-source-newline": true,
     "number-leading-zero": "always",


### PR DESCRIPTION
These rules lint for empty CSS/Sass files and files that start with
an empty line.

Documentation:

- https://stylelint.io/user-guide/rules/no-empty-source
- https://stylelint.io/user-guide/rules/no-empty-first-line