### PR TITLE
Lint for redundant shorthand values

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
     "comment-whitespace-inside": "always",
     "declaration-bang-space-after": "never",
     "declaration-bang-space-before": "always",
+    "declaration-block-no-redundant-longhand-properties": true,
     "declaration-block-semicolon-newline-after": "always-multi-line",
     "declaration-block-trailing-semicolon": "always",
     "declaration-colon-space-after": "always-single-line",


### PR DESCRIPTION
This rule lints for redundant values in shorthand properties. It will
catch things like…

These redundant values:

```scss
a { margin: 1px 1px 1px 1px; }
//              ↑   ↑   ↑
```

Documentation:
https://stylelint.io/user-guide/rules/shorthand-property-no-redundant-values