### PR TITLE
Enable `max-empty-lines` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = {
     "function-url-quotes": "always",
     "indentation": 2,
     "length-zero-no-unit": true,
+    "max-empty-lines": 1,
     "max-nesting-depth": 3,
     "media-query-list-comma-newline-after": "always-multi-line",
     "media-query-list-comma-newline-before": "never-multi-line",


### PR DESCRIPTION
This rule lints the number of adjacent empty lines. It will catch things
like…

Extraneous empty lines:

```scss
a {}



b {}
```

Documentation: https://stylelint.io/user-guide/rules/max-empty-lines