### PR TITLE
Enable `max-line-length` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = {
     "indentation": 2,
     "length-zero-no-unit": true,
     "max-empty-lines": 1,
+    "max-line-length": 80,
     "max-nesting-depth": 3,
     "media-query-list-comma-newline-after": "always-multi-line",
     "media-query-list-comma-newline-before": "never-multi-line",


### PR DESCRIPTION
This rule lints for the maximum number of characters on a line. It will
catch things like…

A media query that should be broken onto multiple lines:

```scss
@media screen and (min-width: $breakpoint-variable), and (orientation: landscape) {}
```

Documentation: https://stylelint.io/user-guide/rules/max-line-length