### PR TITLE
Change `color-hex-length` to `long`

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
     "block-opening-brace-newline-after": "always-multi-line",
     "block-opening-brace-space-before": "always",
     "color-hex-case": "lower",
-    "color-hex-length": "short",
+    "color-hex-length": "long",
     "color-named": "never",
     "comment-whitespace-inside": "always",
     "declaration-bang-space-after": "never",


### PR DESCRIPTION
Based on [a comment from Eric Bailey][comment]:

> What do you think about using the longhand hex value? I know it's
> nitpicky, but I like the consistency of always having one treatment
> for the declaration type.

Since many hex values can't be shortened, let's instead consistently
use the longhand notation.

[comment]: https://github.com/thoughtbot/guides/pull/551#discussion_r285159782