### PR TITLE
Updates the deprecated whitelist and blacklist rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,10 +25,10 @@ module.exports = {
     "declaration-colon-space-after": "always-single-line",
     "declaration-colon-space-before": "never",
     "declaration-no-important": true,
-    "declaration-property-unit-whitelist": {
+    "declaration-property-unit-allowed-list": {
       "line-height": []
     },
-    "declaration-property-value-blacklist": {
+    "declaration-property-value-disallowed-list": {
       "/^transition/": ["/all/"]
     },
     "function-calc-no-invalid": true,


### PR DESCRIPTION
# Problem

Currently the rule list uses two deprecated rules:

- Deprecation Warning: 'declaration-property-unit-whitelist' has been deprecated. Instead use 'declaration-property-unit-allowed-list'. See: https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/declaration-property-unit-whitelist/README.md
- Deprecation Warning: 'declaration-property-value-blacklist' has been deprecated. Instead use 'declaration-property-value-disallowed-list'. See: https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/declaration-property-value-blacklist/README.md

# Solution

This PR fixes these deprecation's by changing:

- `declaration-property-unit-whitelist` &rarr; `declaration-property-unit-allowed-list`
- `declaration-property-unit-blacklist` &rarr; `declaration-property-unit-disallowed-list`

Fixes #33