### PR TITLE
Remove deprecated function-calc-no-invalid rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,6 @@ module.exports = {
     "declaration-property-value-blacklist": {
       "/^transition/": ["/all/"]
     },
-    "function-calc-no-invalid": true,
     "function-comma-space-after": "always-single-line",
     "function-comma-space-before": "never",
     "function-parentheses-space-inside": "never-single-line",


### PR DESCRIPTION
The `function-calc-no-invalid` rule [was deprecated a while ago](https://github.com/stylelint/stylelint/pull/5296). It outputs an error during linting. The fix is to remove the rule.