### PR TITLE
Remove Atom editor configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,22 +55,6 @@ You can also turn a rule off, by setting the value of the rule to `null`:
 
 [stylelint-configuration]: https://stylelint.io/user-guide/configuration/
 
-### Atom integration
-
-stylelint can be integrated into [Atom][atom] so that you will be alerted of
-any warnings and errors inline, while you work.
-
-Install the [linter][linter] and [linter-stylelint][linter-stylelint] packages
-using Atom’s package manager or enter this into your terminal:
-
-```bash
-apm install linter linter-stylelint
-```
-
-[atom]: https://atom.io/
-[linter]: https://atom.io/packages/linter
-[linter-stylelint]: https://atom.io/packages/linter-stylelint
-
 ## License
 
 thoughtbot stylelint Config is copyright (c) 2020


### PR DESCRIPTION
Those who would've been using Atom have very likely switched to VS Code now, and leaving this here looks dated. Those still using it can certainly figure out the configuration themselves.