### PR TITLE
Allow !default annotations

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,12 @@ module.exports = {
     'stylelint-order',
   ],
   rules: {
+    'annotation-no-unknown': [
+      true,
+      {
+        ignoreAnnotations: ['default', 'global'],
+      },
+    ],
     'at-rule-no-unknown': null,
     'color-hex-length': 'long',
     'color-named': 'never',


### PR DESCRIPTION
In addition to being valid SCSS, we often use `!default` in places like `variables.scss`.

https://github.com/stylelint-scss/stylelint-config-recommended-scss/issues/131 https://github.com/stylelint-scss/stylelint-config-recommended-scss/pull/132