### PR TITLE
Add a script to automate building the CHANGELOG

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,8 +5,9 @@ Config. It’s for thoughtbot employees.
 
 1. Make sure you’re on the `main` branch with a clean working directory.
 
-1. Update the [changelog][changelog], following the guidelines from
-   [keep a changelog][keep-a-changelog]
+1. Run `bin/build-changelog` to put together the entries for the CHANGELOG. You
+   might wish to edit it or make other minor changes. Then, you can update
+   `CHANGELOG.md`.
 
 1. Run `npm version [major | minor | patch] --force`
 

--- a/bin/build-changelog
+++ b/bin/build-changelog
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+if ! command -v gh > /dev/null; then
+  echo "Please install the GitHub CLI: https://cli.github.com/"
+  exit 1
+fi
+
+last_release=$(git describe --tag --abbrev=0)
+
+revision_range="${last_release}..origin/main"
+commit_format="--pretty=tformat:%h %s"
+commits_since=$(git log --author="^(?!dependabot).*$" --perl-regexp "${revision_range}" "${commit_format}")
+
+echo "$commits_since" | while read -r line; do
+	sha=$(echo "${line}" | awk '{print $1}')
+	commit_message=$(echo "${line}" | awk '{print substr($0, index($0, " ")+1)}')
+
+	pr_number=$(gh pr list --search "$sha" --state merged --json number --jq '.[].number')
+	trimmed_commit=$(echo "${commit_message}"| sed "s/ (\#$pr_number)//g")
+
+	echo "* ${trimmed_commit} (#${pr_number})"
+done


### PR DESCRIPTION
Taken from Administrate, this helps build a Markdown snippet of the changes since the last known tag, which gets linked to the PR which introduced it.

In most cases you do need to do a bit of extra work, but the output can be copy and pasted into the `CHANGELOG.md` file.

https://github.com/thoughtbot/administrate/blob/main/bin/build-changelog