### PR TITLE
Narrowly specify the desired transition declaration

### DIFF
--- a/__tests__/valid.scss
+++ b/__tests__/valid.scss
@@ -35,6 +35,7 @@ $map: (
   align-items: center;
   display: flex;
   flex: 1 1 auto;
+  transition-behavior: allow-discrete;
 
   a {
     text-decoration: none;

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
       'line-height': [],
     },
     'declaration-property-value-disallowed-list': {
-      '/^transition/': ['/all/'],
+      '/^transition/': ['/^all /'],
     },
     'declaration-property-value-no-unknown': null,
     'function-url-quotes': 'always',


### PR DESCRIPTION
This repo was created from the thoughtbot guides' Stylelint config. That config was created in https://github.com/thoughtbot/guides/pull/522, which mentioned the SCSS-Lint config that used to be there.

The final version of that referenced SCSS-Lint config is [here][scss-lint-config]. It turns on the rule `TransitionAll` (documented [here][transition-all]):

>TransitionAll
>Don't use the all keyword to specify transition properties.
>
>Bad: use of `transition all`
>
>```css
>transition: all .5s ease-in;
> ```
>
>Good: explicitly specify properties to transition
>```css
>transition: color .5s ease-in, margin-bottom .5s ease-in;
> ```

As you can see, the goal is to avoid `all`, but it catches the following as well:

```css
transition-behavior: allow-discrete;
```

MDN docs for `transition-behavior` are [here][mdn].

To fix this, the regex is now more specific, and there is a test for it using the `transition-behavior` property.

[scss-lint-config]: https://github.com/thoughtbot/guides/commit/91ebdf6a3c96a1610a2d8f59ffd6ddd4f78cdd1f
[transition-all]: https://github.com/sds/scss-lint/blob/main/lib/scss_lint/linter/README.md#transitionall
[mdn]: https://developer.mozilla.org/en-US/docs/Web/CSS/transition-behavior