### PR TITLE
Specify Node version manually

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
       - run: npm ci
       - run: npm test
 


### PR DESCRIPTION
Unlike other language setup actions, you need to manually set this, otherwise it won't use it. Wild.